### PR TITLE
Update model path in AuthServiceProvider's policies.

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -13,7 +13,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array
      */
     protected $policies = [
-        // 'App\Model' => 'App\Policies\ModelPolicy',
+        // 'App\Models\Model' => 'App\Policies\ModelPolicy',
     ];
 
     /**


### PR DESCRIPTION
Due to the change of default model location in Laravel 8.x from /App to /App/Models, the initial policy comment shoud also reflect this change.